### PR TITLE
docs: align hub deployment with 1.0 release, minor updates for miniku…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ npm-debug.log*
 .idea
 reports
 cache
+.tool-versions

--- a/src/.vitepress/routes/sidebar/deployment.ts
+++ b/src/.vitepress/routes/sidebar/deployment.ts
@@ -10,8 +10,9 @@ export const deploymentRoutes = [
     {
         text: 'Hub Deployment',
         items: [
+            { text: 'Overview', link: '/hub-introduction' },
             { text: 'Helm Chart Installation', link: '/hub-installation' },
-            { text: 'Storage Setup', link: '/hub-storage' },
+            { text: 'Storage', link: '/hub-storage' },
             { text: 'Docker Compose (Dev)', link: '/hub-docker-compose' },
         ]
     },

--- a/src/guide/deployment/hub-docker-compose.md
+++ b/src/guide/deployment/hub-docker-compose.md
@@ -1,33 +1,63 @@
-# FLAME Hub Docker Compose
+# FLAME Hub with Docker Compose
 
-Clone the [Hub Deployment repository](https://github.com/privateaim/hub-deployment.git):
+The Docker Compose setup is intended for development and evaluation. It uses fixed development
+credentials, mounts the Docker socket for the core worker, and does not include Harbor. Use the
+[Helm deployment](./hub-installation) for a production Hub.
+
+## Get the configuration
+
+Clone the repository and enter the Compose directory:
+
 ```bash
-git clone https://github.com/privateaim/hub-deployment.git
+git clone https://github.com/PrivateAIM/hub-deployment.git
+cd hub-deployment/docker-compose
+cp .env.example .env
 ```
 
-## Note on Harbor
-This setup does not include the Harbor service, you must either provide the credentials to an existing Harbor or [install Harbor separately](https://goharbor.io/docs/latest/install-config/).
+The executable configuration remains in the Hub Deployment repository:
 
-## Configuration
-Basic configuration occurs via environment variables in an `.env` file.
-An example (`.env.example`) is located in the root of the repository.
+- [`docker-compose.yml`](https://github.com/PrivateAIM/hub-deployment/blob/master/docker-compose/docker-compose.yml)
+- [`nginx.conf`](https://github.com/PrivateAIM/hub-deployment/blob/master/docker-compose/nginx.conf)
+- [`.env.example`](https://github.com/PrivateAIM/hub-deployment/blob/master/docker-compose/.env.example)
 
-| Variable        | Mandatory | Default | Use/Meaning                                                       |
-|-----------------|:---------:|---------|-------------------------------------------------------------------|
-| `HUB_IMAGE`     |     ❌     | `ghcr.io/privateaim/hub` | Used to override the default image for the `HUB` docker image     |
-| `HUB_IMAGE_TAG` |     ❌     | `latest` | Used to override the default image tag for the `HUB` docker image |
-| `SUBNET`        |     ❌     | `172.40.1.0/24` | Used to change the default docker subnet.                         |
+## Configure the environment
 
-To provide credentials to Harbor (either local or external), use the following Variable:
-> ⚠️ Important: Harbor must be accessible via https (plain http will fail). This is a limitation of Harbor.
+The example `.env` supports these basic overrides:
 
-| Variable        | Mandatory | Use/Meaning                                                       |
-|-----------------|:---------:|-------------------------------------------------------------------|
-| `HARBOR_URL`    |     ✅     | Construct using `<username>:<passwd>@<harbor_host>` (no `https://` ) |
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `HUB_IMAGE` | `ghcr.io/privateaim/hub` | Hub container image repository |
+| `HUB_IMAGE_TAG` | `latest` | Hub image tag |
+| `SUBNET` | `172.40.1.0/24` | Compose network subnet |
 
-## Run
+The Compose file also accepts service URL overrides such as `PUBLIC_URL`, `AUTHUP_PUBLIC_URL`,
+`CORE_PUBLIC_URL`, and `STORAGE_PUBLIC_URL`. Review the current Compose file before changing them.
 
-Run using:
+Analyses require a reachable Harbor registry. This setup does not deploy one, so either
+[install Harbor separately](https://goharbor.io/docs/latest/install-config/) or use an existing
+instance. Harbor must be reachable over HTTPS. Set `HARBOR_URL` without the scheme and include the
+credentials:
+
+```dotenv
+HARBOR_URL=<username>:<password>@<harbor-host>
+```
+
+Do not commit the populated `.env` file.
+
+## Start and inspect the stack
+
 ```bash
 docker compose up -d
+docker compose ps
+docker compose logs -f
 ```
+
+The bundled NGINX listens on `http://localhost:3000` and routes the Hub services by path. Stop the
+stack with:
+
+```bash
+docker compose down
+```
+
+Named volumes retain database and object-store data. Use `docker compose down --volumes` only when
+you intentionally want to delete that local data.

--- a/src/guide/deployment/hub-installation.md
+++ b/src/guide/deployment/hub-installation.md
@@ -1,71 +1,204 @@
-# FLAME Hub Helm Chart
+# Install the FLAME Hub with Helm
 
-The FLAME Hub Chart provides a default configuration in `values.yaml` but is meant to be installed with your own adjusted override values file, e.g. `values_local.yaml`.
-To get an overview of all configuration options, see the [`values.yaml` in the Helm Repository](https://github.com/PrivateAIM/helm/blob/master/charts/flame-hub/values.yaml)
-You can choose if you want to use the chart's harbor or a separate external harbor instance.
+The FLAME Hub chart installs the Hub services, PostgreSQL, SeaweedFS, the enabled observability and
+messaging dependencies, and optionally a bundled Harbor registry. Keep site-specific configuration
+in an override file; do not copy the complete default `values.yaml`, because copied defaults become
+stale during upgrades.
 
-## Prerequisites:
-* Existing k8s distribution (see [microk8s-quickstart](./microk8s-quickstart) or [minikube-quickstart](./minikube-quickstart) for a guide)
-  * Ingress addon
-  * Default StorageClass (e.g. hostpath-storage addon in microk8s)
-* Two domain names (one for the Hub, one for Harbor). If you run the Hub on your local machine, you can choose them freely and set them in your hosts file  (`/etc/hosts`)
+## Prerequisites
 
-## Storage
-The chart will use whichever storage class is the default in your cluster, unless you specify otherwise in the values. See [Storage Setup](./hub-storage) for instructions how to setup Mayastor Storage Replication. This requires 3+ nodes in your cluster and will replicate persistent volumes across them.
+- Kubernetes and Helm 3 are available from the operator workstation.
+- The chosen [StorageClass](./hub-storage) has been tested.
+- An Ingress controller or Gateway API controller is installed.
+- DNS and TLS are prepared for the Hub hostname and, when bundled Harbor is enabled, a separate
+  Harbor hostname.
+- The target namespace has been chosen. Prefer one Hub release per namespace.
 
-## Ingress
-See the `values.yaml` for ingress options. The default ingress configuration will use path-based routing for all services except Harbor (which requires its own hostname). You will have to provide an extra (sub)domain if you want to use the harbor component of this chart. The current setup does not automatically acquire TLS certificates.
+Harbor cannot be hosted below the Hub's path. If it is enabled, it needs its own hostname.
 
-## Installing the FLAME Hub Chart
+## Choose Ingress or Gateway API
 
-### 1. Option: Official Chart Repo
-```bash
-helm repo add flame https://PrivateAIM.github.io/helm
-helm repo update
-```
-Create your custom values file (instructions below).
-```bash
-helm install <release-name> -f <values-file> flame/hub
-```
+The chart supports both routing models.
 
-### 2. Option: Chart Source Code
-> Choose this option if you want to
->
-> a) modify not only the chart values, but also the chart files.
->
-> b) run the newest, not yet released version of the chart.
+### Ingress
 
-```bash
-git clone https://github.com/PrivateAIM/helm.git
-cd helm
-cd charts/flame-hub
-```
-Create your custom values file (instructions below).
+Enable `global.flameHub.ingress` for path-based routing through one Hub hostname. The default
+annotations target ingress-nginx and include the body-size and timeout settings required for large
+uploads. Replace them when using another controller. Harbor has its own ingress block and hostname.
+
+### Gateway API
+
+The chart is tested with
+[NGINX Gateway Fabric](https://docs.nginx.com/nginx-gateway-fabric/install/helm/). Install the Gateway
+API resources supported by the selected NGF release before installing its controller. The commands
+below pin NGF and its Gateway API resources to the same release. FLAME uses NGF's `SnippetsPolicy`,
+which is disabled by default and must be enabled explicitly:
 
 ```bash
-helm install <release name> -f <values-file> .
+NGF_VERSION=v2.6.7
+
+kubectl kustomize \
+  "https://github.com/nginx/nginx-gateway-fabric/config/crd/gateway-api/standard?ref=${NGF_VERSION}" \
+  | kubectl apply -f -
+
+helm upgrade --install ngf oci://ghcr.io/nginx/charts/nginx-gateway-fabric \
+  --namespace nginx-gateway --create-namespace \
+  --version "${NGF_VERSION#v}" \
+  --set nginxGateway.snippets.enable=true
 ```
 
-## Minimal configuration using custom values file
+The experimental Gateway API channel is an alternative to the standard channel when another
+required feature needs it; do not install both. Snippets do not by themselves require the
+experimental channel.
 
-This is the values-file mentioned in the sections above. Call it `override_values.yaml` or whatever you want.
+For a simple self-managed cluster without a `LoadBalancer` implementation, NGF can instead run as a
+DaemonSet with fixed NodePorts:
+
+```bash
+NGF_VERSION=v2.6.7
+
+helm upgrade --install ngf oci://ghcr.io/nginx/charts/nginx-gateway-fabric \
+  --namespace nginx-gateway --create-namespace \
+  --version "${NGF_VERSION#v}" \
+  --set nginxGateway.snippets.enable=true \
+  --set nginx.kind=daemonSet \
+  --set nginx.service.type=NodePort \
+  --set nginx.service.externalTrafficPolicy=Local \
+  --set-json 'nginx.service.nodePorts=[{"port":31437,"listenerPort":80},{"port":30478,"listenerPort":443}]'
+```
+
+This exposes the listeners on the selected ports of each eligible node. Configure the public reverse
+proxy or load balancer to route to those ports. Adapt the Service type, ports, Gateway listeners,
+DNS, and TLS to the target infrastructure; the NodePort layout is not a universal production
+network design.
+
+The chart can create its own Gateway, or attach HTTPRoutes to an existing Gateway. Enable
+`global.flameHub.gatewayApi.enabled` and set `nginxGatewayFabric.snippets: true` when using NGF.
+An external Gateway requires a `parentRef` and may require a `ReferenceGrant` when it lives in a
+different namespace.
+
+### Minimum Gateway API values
+
+This minimal example creates a TLS-enabled Gateway for the Hub and bundled Harbor. The referenced
+Secret must contain a certificate valid for both `hub.test` and `harbor.test`:
 
 ```yaml
 global:
   flameHub:
+    publicHttps: true
     ingress:
+      enabled: false
+    gatewayApi:
       enabled: true
-      ssl: true
-      hostname: "hub.local"
-
-grafana:
-  # disable plugins until plugin issues are fixed
-  plugins:
+      hostname: hub.test
+      tls:
+        enabled: true
+        certificateRef: hub-local-tls
+      gateway:
+        gatewayClassName: nginx
+      nginxGatewayFabric:
+        snippets: true
 
 harbor:
   enabled: true
-  externalURL: "https://harbor.hub.local/" # don't forget https://
+  externalURL: https://harbor.test
+  ingress:
+    enabled: false
+  gatewayApi:
+    enabled: true
 ```
 
-## Accessing the hub
-For accessing the hub in a **minikube** installation, refer to the [Minikube Setup: Accessing Deployments](./minikube-quickstart)
+Harbor inherits the global Gateway certificate settings. Set `harbor.gatewayApi.tls` only when its
+hostname uses a different certificate. See the current
+[`values.yaml`](https://github.com/PrivateAIM/helm/blob/master/charts/flame-hub/values.yaml) for all
+fields.
+
+## Install from the chart repository
+
+```bash
+helm repo add flame https://PrivateAIM.github.io/helm
+helm repo update
+helm show values flame/hub > values-reference.yaml
+```
+
+Create a small `values-hub.yaml`. This Ingress example relies on the chart defaults for generated
+credentials and the default StorageClass:
+
+```yaml
+global:
+  flameHub:
+    publicHttps: true
+    ingress:
+      enabled: true
+      hostname: hub.test
+
+authup:
+  publicURL: https://hub.test
+
+harbor:
+  enabled: true
+  externalURL: https://harbor.test
+  ingress:
+    enabled: true
+```
+
+Compare this example with the current
+[`values_min.yaml`](https://github.com/PrivateAIM/helm/blob/master/charts/flame-hub/values_min.yaml)
+and [`values.yaml`](https://github.com/PrivateAIM/helm/blob/master/charts/flame-hub/values.yaml)
+before use.
+
+Install into a dedicated namespace:
+
+```bash
+helm upgrade --install flame-hub flame/hub \
+  --namespace flame-hub --create-namespace \
+  --values values-hub.yaml \
+  --wait --timeout 15m
+```
+
+To work on unreleased chart source instead, clone the Helm repository, run
+`helm dependency update charts/flame-hub`, and use `./charts/flame-hub` as the chart argument.
+
+## Credentials and Secrets
+
+On first installation the chart generates random values and keeps them in three Secrets:
+
+| Secret | Purpose |
+| --- | --- |
+| `flame-hub-auth` | RabbitMQ, Redis, Grafana, and authup credentials and connection strings |
+| `flame-hub-pg` | PostgreSQL username and password; also used by Harbor |
+| `flame-hub-harbor` | Harbor admin password, connection string, and the 16-character core `secretKey` |
+
+Retrieve initial administrator passwords with:
+
+```bash
+kubectl -n flame-hub get secret flame-hub-auth \
+  -o jsonpath='{.data.authup-admin-password}' | base64 -d; echo
+
+kubectl -n flame-hub get secret flame-hub-harbor \
+  -o jsonpath='{.data.harbor-admin-password}' | base64 -d; echo
+```
+
+For a managed installation, create and back up the Secrets before Helm or use the chart's
+`existingSecret` settings. Preserve `flame-hub-harbor.secretKey`: Harbor uses it to decrypt robot
+tokens and replication credentials. Chart-managed Secrets and important PVCs carry Helm's `keep`
+policy and can remain after `helm uninstall`; inventory them explicitly during cleanup.
+
+## Verify the installation
+
+```bash
+kubectl -n flame-hub get pods,pvc
+kubectl -n flame-hub get ingress,httproute,gateway
+helm -n flame-hub status flame-hub
+```
+
+Wait for every StatefulSet and Deployment to become ready. Then verify Hub login, Harbor login and
+push/pull, an analysis workflow, and object storage access. A successful Helm release alone is not a
+data-level acceptance test.
+
+## Multiple releases in one namespace
+
+Several dependency charts cannot template resource names. If multiple Hub releases must share a
+namespace, assign unique PostgreSQL Service/Secret, central auth Secret, Harbor Service/Secret, and
+matching dependency references. The complete list is maintained in the
+[chart README](https://github.com/PrivateAIM/helm/tree/master/charts/flame-hub#running-multiple-releases-in-the-same-namespace).

--- a/src/guide/deployment/hub-installation.md
+++ b/src/guide/deployment/hub-installation.md
@@ -10,9 +10,6 @@ stale during upgrades.
 - Kubernetes and Helm 3 are available from the operator workstation.
 - The chosen [StorageClass](./hub-storage) has been tested.
 - An Ingress controller or Gateway API controller is installed.
-- DNS and TLS are prepared for the Hub hostname and, when bundled Harbor is enabled, a separate
-  Harbor hostname.
-- The target namespace has been chosen. Prefer one Hub release per namespace.
 
 Harbor cannot be hosted below the Hub's path. If it is enabled, it needs its own hostname.
 
@@ -32,7 +29,7 @@ The chart is tested with
 [NGINX Gateway Fabric](https://docs.nginx.com/nginx-gateway-fabric/install/helm/). Install the Gateway
 API resources supported by the selected NGF release before installing its controller. The commands
 below pin NGF and its Gateway API resources to the same release. FLAME uses NGF's `SnippetsPolicy`,
-which is disabled by default and must be enabled explicitly:
+which is disabled by default and must be enabled explicitly.For a simple self-managed cluster without a `LoadBalancer` implementation, NGF can instead run as a DaemonSet with fixed NodePorts:
 
 ```bash
 NGF_VERSION=v2.6.7
@@ -44,22 +41,6 @@ kubectl kustomize \
 helm upgrade --install ngf oci://ghcr.io/nginx/charts/nginx-gateway-fabric \
   --namespace nginx-gateway --create-namespace \
   --version "${NGF_VERSION#v}" \
-  --set nginxGateway.snippets.enable=true
-```
-
-The experimental Gateway API channel is an alternative to the standard channel when another
-required feature needs it; do not install both. Snippets do not by themselves require the
-experimental channel.
-
-For a simple self-managed cluster without a `LoadBalancer` implementation, NGF can instead run as a
-DaemonSet with fixed NodePorts:
-
-```bash
-NGF_VERSION=v2.6.7
-
-helm upgrade --install ngf oci://ghcr.io/nginx/charts/nginx-gateway-fabric \
-  --namespace nginx-gateway --create-namespace \
-  --version "${NGF_VERSION#v}" \
   --set nginxGateway.snippets.enable=true \
   --set nginx.kind=daemonSet \
   --set nginx.service.type=NodePort \
@@ -67,10 +48,9 @@ helm upgrade --install ngf oci://ghcr.io/nginx/charts/nginx-gateway-fabric \
   --set-json 'nginx.service.nodePorts=[{"port":31437,"listenerPort":80},{"port":30478,"listenerPort":443}]'
 ```
 
+
 This exposes the listeners on the selected ports of each eligible node. Configure the public reverse
-proxy or load balancer to route to those ports. Adapt the Service type, ports, Gateway listeners,
-DNS, and TLS to the target infrastructure; the NodePort layout is not a universal production
-network design.
+proxy or load balancer to route to those ports.
 
 The chart can create its own Gateway, or attach HTTPRoutes to an existing Gateway. Enable
 `global.flameHub.gatewayApi.enabled` and set `nginxGatewayFabric.snippets: true` when using NGF.
@@ -179,22 +159,17 @@ kubectl -n flame-hub get secret flame-hub-harbor \
   -o jsonpath='{.data.harbor-admin-password}' | base64 -d; echo
 ```
 
-For a managed installation, create and back up the Secrets before Helm or use the chart's
-`existingSecret` settings. Preserve `flame-hub-harbor.secretKey`: Harbor uses it to decrypt robot
-tokens and replication credentials. Chart-managed Secrets and important PVCs carry Helm's `keep`
+Chart-managed Secrets and important PVCs carry Helm's `keep`
 policy and can remain after `helm uninstall`; inventory them explicitly during cleanup.
 
 ## Verify the installation
 
 ```bash
 kubectl -n flame-hub get pods,pvc
-kubectl -n flame-hub get ingress,httproute,gateway
+kubectl -n flame-hub get httproute,gateway # (or ingress)
 helm -n flame-hub status flame-hub
 ```
 
-Wait for every StatefulSet and Deployment to become ready. Then verify Hub login, Harbor login and
-push/pull, an analysis workflow, and object storage access. A successful Helm release alone is not a
-data-level acceptance test.
 
 ## Multiple releases in one namespace
 

--- a/src/guide/deployment/hub-installation.md
+++ b/src/guide/deployment/hub-installation.md
@@ -29,7 +29,7 @@ The chart is tested with
 [NGINX Gateway Fabric](https://docs.nginx.com/nginx-gateway-fabric/install/helm/). Install the Gateway
 API resources supported by the selected NGF release before installing its controller. The commands
 below pin NGF and its Gateway API resources to the same release. FLAME uses NGF's `SnippetsPolicy`,
-which is disabled by default and must be enabled explicitly.For a simple self-managed cluster without a `LoadBalancer` implementation, NGF can instead run as a DaemonSet with fixed NodePorts:
+which is disabled by default and must be enabled explicitly. For a simple self-managed cluster without a `LoadBalancer` implementation, NGF can instead run as a DaemonSet with fixed NodePorts:
 
 ```bash
 NGF_VERSION=v2.6.7

--- a/src/guide/deployment/hub-introduction.md
+++ b/src/guide/deployment/hub-introduction.md
@@ -1,13 +1,41 @@
-# Introduction 
-::: warning Info
-This section is only required if you want to use the FLAME software completely independently of the PrivateAim infrastructure provided by  https://privateaim.net
-:::
-## Requirements
-The following guide is based on some shared assumptions:
+# FLAME Hub deployment
 
-- OS `debian` or `ubuntu`
-- Nginx `v1.18.x` is installed
-- Docker `v20.x` is installed
-- Min. `4` cores
-- Min. `20G` hard disk
-- Domains with certificates
+This section describes a standalone FLAME Hub deployment. The supported production path is the
+[FLAME Hub Helm chart](https://github.com/PrivateAIM/helm/tree/master/charts/flame-hub) on Kubernetes.
+Docker Compose is available for development and evaluation, but it does not include Harbor and is
+not the recommended production topology.
+
+## What the chart installs
+
+The Hub chart installs the FLAME services and their supporting components, including:
+
+- Core FLAME Hub services
+- Databases, S3 Storage, Message Broker
+- Harbor for storing container images (optional, you can also bring your own)
+- Ingress or HTTPRoute/Gateway, but **no Ingress controller or Gateway Controller**
+
+## Baseline requirements
+
+- A supported Kubernetes cluster and Helm 3.
+- A default `StorageClass`, or explicit storage classes for every persistent component.
+- At least 4 CPU cores and enough memory and storage for the enabled services. Capacity depends on
+  the number and size of analyses; the worker and registry volumes usually dominate.
+- A DNS name for the Hub. If the bundled Harbor registry is enabled, it needs a separate hostname.
+- An Ingress controller or a Gateway API implementation. The chart is tested with NGINX Gateway
+  Fabric when using Gateway API.
+- TLS certificates for every public hostname in a real deployment.
+
+For an OpenStack-hosted cluster, use the OpenStack Cinder CSI driver and a suitable Cinder
+`StorageClass`. Cinder/Ceph already supplies durable, reattachable block storage; adding Mayastor on
+top is not recommended.
+
+## Repository responsibilities
+
+- This documentation repository owns the deployment concepts and complete guides.
+- [`PrivateAIM/hub-deployment`](https://github.com/PrivateAIM/hub-deployment) contains small helper
+  scripts, copyable configuration snippets and the docker-compose file.
+- [`PrivateAIM/helm`](https://github.com/PrivateAIM/helm) owns the chart, default values, and the
+  exhaustive value reference.
+
+Continue with [Kubernetes preparation](./microk8s-quickstart) or go directly to
+[installing the Hub chart](./hub-installation) if a cluster is already available.

--- a/src/guide/deployment/hub-introduction.md
+++ b/src/guide/deployment/hub-introduction.md
@@ -26,8 +26,7 @@ The Hub chart installs the FLAME services and their supporting components, inclu
 - TLS certificates for every public hostname in a real deployment.
 
 For an OpenStack-hosted cluster, use the OpenStack Cinder CSI driver and a suitable Cinder
-`StorageClass`. Cinder/Ceph already supplies durable, reattachable block storage; adding Mayastor on
-top is not recommended.
+`StorageClass`. Cinder/Ceph supplies durable, reattachable block storage.
 
 ## Repository responsibilities
 

--- a/src/guide/deployment/hub-storage.md
+++ b/src/guide/deployment/hub-storage.md
@@ -7,8 +7,7 @@ configured for a component.
 ## Recommended model
 
 Use a CSI-backed volume service that provides durable block storage and supports detaching a volume
-from a failed VM and reattaching it to the replacement node. Examples include OpenStack Cinder,
-managed cloud block storage, and a storage system operated directly by the Kubernetes platform.
+from a failed VM and reattaching it to the replacement node.
 
 For FLAME clusters running as virtual machines on OpenStack, the recommended choice is the
 [OpenStack Cinder CSI driver](https://github.com/kubernetes/cloud-provider-openstack). When the
@@ -28,8 +27,7 @@ kubectl get storageclass
 ## Configure the chart
 
 If the correct class is the cluster default, no storage override is necessary. Otherwise set the
-same durable class on each persistent component in your override file. The exact keys can change as
-upstream subcharts evolve, so use the current
+same durable class on each persistent component in your override file. The exact keys can change, so use the current
 [`values.yaml`](https://github.com/PrivateAIM/helm/blob/master/charts/flame-hub/values.yaml) as the
 reference.
 

--- a/src/guide/deployment/hub-storage.md
+++ b/src/guide/deployment/hub-storage.md
@@ -1,103 +1,57 @@
-# OpenEBS/Mayastor for FLAME (optional)
+# Storage for the FLAME Hub
 
-OpenEBS is a chart that provides extra storage options. We will be using Mayastor Replicated Storage to synchronize Persistent Volumes across multiple nodes in the cluster. This aims to ensure no data is lost when a node fails. With extra configuration, it enables automatic failover.
+The Hub contains several stateful services. Storage is therefore an infrastructure decision, not
+just a chart setting. The chart uses the cluster's default `StorageClass` unless an explicit class is
+configured for a component.
 
-If you want to enable storage replication, you need to:
-1. Prepare your k8s nodes
-2. Install OpenEBS into your k8s cluster 
-3. Configure your Application (FLAME Hub) to use the new storage class
+## Recommended model
 
-## Node Setup
-Before installing OpenEBS, you must prepare the k8s nodes you want to use for mayastor.
+Use a CSI-backed volume service that provides durable block storage and supports detaching a volume
+from a failed VM and reattaching it to the replacement node. Examples include OpenStack Cinder,
+managed cloud block storage, and a storage system operated directly by the Kubernetes platform.
 
-### Automatic script 🤖
-Use the script `prepare_for_mayastor.sh`.
-> The script has been tested in Debian.
->
-> The script can safely be run multiple times.
-
-Download the script: [prepare_for_mayastor.sh](https://github.com/PrivateAIM/hub-deployment/tree/master/scripts)
-
-```bash
-chmod +x prepare_for_mayastor.sh
-sudo ./prepare_for_mayastor.sh
-```
-Alternatively, you can manually do the following:
-
-### 1. Configure hugepages
-Enable hugepages:
-```bash
-echo 1024 > /sys/kernel/mm/hugepages/hugepages-2048kB/nr_hugepages
-```
-Persist hugepages and apply:
-```bash
-echo "vm.nr_hugepages = 1024" > /etc/sysctl.d/20-microk8s-hugepages.conf
-sysctl --system
-```
-
-### 2. Load NVMe-oF module
-Load the module immediately:
-```bash
-modprobe nvme-tcp
-```
-Persist the module across reboots:
-   * If `/etc/modules-load.d/nvme-tcp.conf` does not exist or does not
-     contain `nvme-tcp`, create it with:
-```bash
-echo "nvme-tcp" > /etc/modules-load.d/nvme-tcp.conf
-```
-
-### 3. Verify
-Check hugepages:
-```bash
-grep HugePages_Total /proc/meminfo
-```
-Check the module is active:
-```bash
-lsmod | grep nvme_tcp
-```
-
-### 4. Label the node for Mayastor
-```bash
-kubectl label node <node_name> openebs.io/engine=mayastor
-```
-
-## Installing OpenEBS
-
-The FLAME Helm repository provides a [wrapper chart for OpenEBS](https://github.com/PrivateAIM/helm/blob/master/charts/third-party/openebs) with some suggested default values.
-Installing this chart will add a new StorageClass to your cluster. You can tell workloads of the Flame Hub to use this StorageClass by specifying it in `flame-hub/values.yaml`. Usually, only stateful workloads (StatefulSets) need replicated storage.
+For FLAME clusters running as virtual machines on OpenStack, the recommended choice is the
+[OpenStack Cinder CSI driver](https://github.com/kubernetes/cloud-provider-openstack). When the
+Cinder volume type is backed by Ceph, replication already happens below Kubernetes. Do not add a
+second Mayastor replication layer on top: it will slow everything down.
 
 
-1. **Clone the [Flame Helm Repository](https://github.com/PrivateAIM/helm/) and navigate to `charts/third-party/openebs`**
-2. Make sure you have 3 nodes in your cluster.
-3. Make sure you have read the previous section on node preparation for mayastor.
-    * If not already labeled, label your nodes:
-`kubectl label node <node_name> openebs.io/engine=mayastor`
-4. Clone `values.yaml` to `values_local.yaml`.
-5. Fill in your kubelet path and populate the disk pools section with your unmounted drives.
-6. Install the chart:
+## Verify the cluster storage
+
+List available classes and identify the default:
 
 ```bash
-helm dependency update .
-```
-```bash
-helm install openebs . --namespace openebs --create-namespace -f values_local.yaml
+kubectl get storageclass
 ```
 
-7. Verify disk pools and `mayastor` storage classes:
-```bash
-kubectl get diskpools -n openebs
-kubectl get storageclasses
-```
-8. Edit your FLAME-Hub values-file to use the new StorageClass. A reinstall of the Hub will probably be required.
 
-## Use the new storage class
+## Configure the chart
 
-In your `values.yaml` (or better `values_override.yaml`) you can specify the storage class for the different components of the FLAME Hub.
+If the correct class is the cluster default, no storage override is necessary. Otherwise set the
+same durable class on each persistent component in your override file. The exact keys can change as
+upstream subcharts evolve, so use the current
+[`values.yaml`](https://github.com/PrivateAIM/helm/blob/master/charts/flame-hub/values.yaml) as the
+reference.
 
-Example:
+The first-party PostgreSQL and SeaweedFS settings look like this:
+
 ```yaml
-minio:
+postgresql:
   persistence:
-    storageClass: "mayastor-replicated"
+    storageClass: <cinder-storage-class>
+    size: 16Gi
+
+seaweedfs:
+  allInOne:
+    data:
+      storageClass: <cinder-storage-class>
+      size: 80Gi
 ```
+
+Also review persistence for Harbor registry/jobservice/Trivy, RabbitMQ, Grafana, Prometheus,
+VictoriaLogs, and `serverCoreWorker`. Size these claims for the expected analysis and retention
+load.
+
+::: warning Storage classes are effectively immutable for existing claims
+Changing a value does not migrate existing data.
+:::

--- a/src/guide/deployment/index.md
+++ b/src/guide/deployment/index.md
@@ -1,33 +1,23 @@
-# Deployment Guide
+# Deployment guide
 
-## Introduction
+FLAME consists of the central Hub and clinic-local Nodes. These guides are the canonical source for
+deploying both components; repositories with scripts link back here instead of maintaining a second
+copy of the instructions.
 
-The FLAME project consists of two major components:
-- **FLAME Hub**: The central component coordinating the nodes.
-- **FLAME Node**: The component installed at data sites (hospitals, research centers) to execute federated learning tasks.
+## Hub deployment
 
-This guide contains instructions for deploying both components.
+1. Read the [Hub deployment overview](./hub-introduction).
+2. Prepare Kubernetes with [MicroK8s](./microk8s-quickstart) or
+   [Minikube](./minikube-quickstart).
+3. Select and verify [persistent storage](./hub-storage).
+4. [Install and configure the Hub Helm chart](./hub-installation).
 
-## Overview
+[Docker Compose](./hub-docker-compose) is available for development and evaluation.
 
-### Hub Deployment
+## Node deployment
 
-Instructions for deploying the FLAME Hub.
-
-- **Production (Kubernetes)**
-    - [Helm Chart Installation](/guide/deployment/hub-installation)
-    - [Storage Setup (Mayastor) (optional)](/guide/deployment/hub-storage)
-- **Development / Test**
-    - [Hub Docker Compose](/guide/deployment/hub-docker-compose)
-
-### Node Deployment
-
-Instructions for deploying a FLAME Node.
-
-**Tasks:**
-
-- [Hub Registration](/guide/deployment/node-registration)
-- Cluster Setup (choose one)
-    - [microk8s](/guide/deployment/microk8s-quickstart)
-    - [minikube](/guide/deployment/minikube-quickstart)
-- [FLAME Node Installation](/guide/deployment/node-installation)
+1. Prepare a cluster with [MicroK8s](./microk8s-quickstart) or
+   [Minikube](./minikube-quickstart).
+2. [Install the FLAME Node](./node-installation).
+3. [Register it with the Hub](./node-registration).
+4. Use the [troubleshooting guide](./node-troubleshooting) when required.

--- a/src/guide/deployment/microk8s-quickstart.md
+++ b/src/guide/deployment/microk8s-quickstart.md
@@ -7,11 +7,11 @@ This guide demonstrates how to get microk8s and Helm running on a debian-based s
 Instead of following the below installation guide, you can also run the bash script:
 > The script has been tested in Debian.
 
-Download: [microk8s_setup.sh](https://github.com/PrivateAIM/hub-deployment/tree/master/scripts)
+Download: [`1_microk8s_setup.sh`](https://github.com/PrivateAIM/hub-deployment/blob/master/scripts/1_microk8s_setup.sh)
 
 ```bash
-chmod +x microk8s_setup.sh
-./microk8s_setup.sh
+chmod +x 1_microk8s_setup.sh
+./1_microk8s_setup.sh
 ```
 
 This script will optionally:
@@ -51,7 +51,7 @@ echo 'export PATH=$PATH:/snap/bin' >> ~/.bashrc && source ~/.bashrc
 ### Prepare Storage before Install (Optional)
 Because we need to be able to download and store several container images, we need to ensure that there is enough disk 
 space available. By default, microk8s will store everything on your root file system located at `/`. 
-Depending on how your server was setup, bulk storage may be located on a different logical volume (LV) than your root 
+Depending on how your server was set up, bulk storage may be located on a different logical volume (LV) than your root
 file system. You can check this by running:
 ```bash
 df -h
@@ -62,11 +62,25 @@ df -h
 (yellow arrow) only has 13GB available, 
 but a different LV mounted at <code>/mnt/vdb1</code> (green arrow) has 435GB.</figcaption></figure>
 
-If you need to use a different LV for storage, you can either:
+If you need to use a separate VM volume, create one filesystem on that volume and mount it. There is
+no need to divide it into a second partition for Mayastor. Then either:
+
+The [`0_format_drives.sh`](https://github.com/PrivateAIM/hub-deployment/blob/master/scripts/0_format_drives.sh)
+helper can prepare an unused volume. It replaces the device with one GPT partition, formats it as
+ext4, adds it to `/etc/fstab`, and mounts it below `/mnt`. This destroys all existing data on the
+selected device and therefore requires the exact device path as confirmation:
+
+```bash
+chmod +x 0_format_drives.sh
+./0_format_drives.sh /dev/vdb
+```
+
+Inspect the device with `lsblk` and confirm that it is the intended unused volume before running the
+script. For NVMe devices, pass the complete disk path, such as `/dev/nvme1n1`, not a partition.
 
 **Option A (Recommended for simplicity):** Mount (or symlink) the SNAP_COMMON directory to your preferred destination.
 ::: tip
-This storage configuration step should be performed **before** installing microk8s to avoid needing to migrate data later.
+This storage configuration step should be performed **before** installing MicroK8s to avoid needing to migrate data later.
 :::
 
 Ensure the target directories exist and then mount the volume:
@@ -85,10 +99,14 @@ echo "/mnt/vdb1/microk8s/common /var/snap/microk8s/common none bind 0 0" | sudo 
 **Option B (after installation):** Configure containerd to use a different root.
 This option is performed **after** installation and shown in the section "Setup microk8s".
 
+For a production or multi-node Hub, do not use hostpath as the durable application-storage layer.
+Install a reattachable CSI backend such as OpenStack Cinder and configure the Hub claims to use its
+StorageClass; see [Storage for the FLAME Hub](./hub-storage).
+
 ### Install microK8s
 Install the `core` dependency along with microk8s using snap:
 ```bash
-sudo snap install core && sudo snap install microk8s --classic --channel=1.32
+sudo snap install core && sudo snap install microk8s --classic
 ```
 
 Verify you can run microk8s:
@@ -176,7 +194,7 @@ Ensure that you can run the following without errors
 
 | Service          | Command            | Expected Output                                    | Troubleshooting Step                                                                                                                                   |
 |------------------|--------------------|----------------------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------|
-| microk8s         | `microk8s version` | `MicroK8s v1.32.3 revision 8148`                   | Check whether the current user is part of the `microk8s` group: `groups` If not, then end the current session and log back in or run `newgrp microk8s` |
+| microk8s         | `microk8s version` | `MicroK8s v1.xx.x revision xxxx`                   | Check whether the current user is part of the `microk8s` group: `groups` If not, then end the current session and log back in or run `newgrp microk8s` |
 | ingress          | `microk8s status`  | `enabled:  <br>...<br>ingress`                     | Enable ingress addon: `microk8s enable ingress`                                                                                                        |
 | hostpath-storage | `microk8s status`  | `enabled:  <br>...<br>hostpath-storage`            | Enable ingress addon: `microk8s enable hostpath-storage`                                                                                               |
 | helm             | `helm list`        | `NAME NAMESPACE REVISION UPDATED STATUS CHART APP VERSION` | Go through the steps in the [Generating the Configuration](#generate-the-configuration) section                                                        |

--- a/src/guide/deployment/minikube-quickstart.md
+++ b/src/guide/deployment/minikube-quickstart.md
@@ -114,8 +114,8 @@ sudo nano /etc/systemd/system/docker.service.d/proxy.conf
 Add the following to `proxy.conf`, replacing the proxy address with the one for your institution:
 ```bash
 [Service]
-Environment="HTTP_PROXY=http://proxy.place.com:3128"
-Environment="HTTPS_PROXY=http://proxy.place.com:3128"
+Environment="HTTP_PROXY=http://proxy.test:3128"
+Environment="HTTPS_PROXY=http://proxy.test:3128"
 Environment="NO_PROXY=localhost,127.0.0.1,10.0.0.0/8"
 ```
 
@@ -248,3 +248,19 @@ Note that this command does not create any output and will run until you interru
 
 ## Final Steps
 At this point, the domain pointing to this server should be routed to minikube. Open a browser and navigate to the domain and you should see an nginx 404 page. If this is true, you can continue with the [FLAME Node Deployment](/guide/deployment/node-installation).
+
+### Local Hub and Harbor names on Windows
+
+For a local FLAME Hub installation, the
+[`minikube-dns.ps1`](https://github.com/PrivateAIM/hub-deployment/blob/master/scripts/minikube-dns.ps1)
+helper adds the Hub and Harbor hostnames at `minikube ip` to the Windows hosts file. Run PowerShell
+as Administrator:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File .\minikube-dns.ps1 `
+  -HubUrl hub.test `
+  -HarborUrl harbor.test
+```
+
+The script leaves matching existing entries unchanged. Both parameters are required; if bundled
+Harbor is disabled, add the Hub hostname manually instead.


### PR DESCRIPTION
…be and microk8s setup

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Documentation**
  - Expanded Hub deployment guidance for Docker Compose and Helm-based Kubernetes installations.
  - Added prerequisites, storage, networking, TLS, credentials, verification, and multi-release setup instructions.
  - Updated storage guidance to focus on durable CSI-backed volumes and clarified migration considerations.
  - Added clearer deployment workflows for Hub and Node environments.
  - Improved MicroK8s and Minikube quickstarts, including storage preparation and Windows hostname setup.
- **Navigation**
  - Added a Hub Deployment overview link.
  - Renamed “Storage Setup” to “Storage” for clearer navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->